### PR TITLE
Update README, correct negative relative time

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This project provides a Python client for interacting with the Gimlet's control 
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/gimletlabs/metricsreader_client.git
-   cd metricsreader_client
+   git clone https://github.com/gimletlabs/metricsample.py.git
+   cd metricsample.py
    ```
 
 2. Install the required packages:
@@ -40,15 +40,15 @@ export GML_API_KEY=your_api_key_here
 ``` bash
 python client.py [--server_addr <server_address>] [--query <query>] [--relative <relative_time_window>]
 ```
-- --server_addr: (Optional) The address of the gRPC server (e.g., app.gimletlabs.ai:443).
-- --query: (Optional) The PromQL query string (default: gml_gem_image_quality_brisque_score).
-- --relative: (Optional) The relative time window to query (default: -5m).
+- `--server_addr`: (Optional) The address of the gRPC server (e.g., app.gimletlabs.ai:443).
+- `--query`: (Optional) The PromQL query string (default: gml_gem_image_quality_brisque_score).
+- `--relative`: (Optional) The relative time window to query (default: 5m).
 
 ### Example
 
 ``` bash
 export GML_API_KEY=your_api_key_here
-python client.py --server_addr app.gimletlabs.ai:443 --query "gml_gem_image_quality_brisque_score" --relative "-10m"
+python client.py --server_addr app.gimletlabs.ai:443 --query "gml_gem_image_quality_brisque_score" --relative "10m"
 ```
 
 ## Code Overview

--- a/client.py
+++ b/client.py
@@ -9,7 +9,7 @@ from tabulate import tabulate
 import argparse
 from colored import attr, fg
 
-def get_range_query_results(server_address, query="gml_gem_image_quality_brisque_score", relative="-5m"):
+def get_range_query_results(server_address, query="gml_gem_image_quality_brisque_score", relative="5m"):
     # Create SSL credentials using default trusted certificates
     credentials = grpc.ssl_channel_credentials()
     channel = grpc.secure_channel(server_address, credentials)


### PR DESCRIPTION
1. The instructions pointed to the wrong repo name
2. The code and instructions made it seem like time should be formatted as negative, e.g. -5m. In Gimlet we do 5m, 10m, etc.  (see https://github.com/gimletlabs/gimlet/blob/61c6aa1eebe98ea49b4a3baa4c9a4af789abd716/src/controlplane/metricsreader/controller/reader.go#L80)